### PR TITLE
Add tests for cpbitmap conversion

### DIFF
--- a/python/convert_cpbitmap.py
+++ b/python/convert_cpbitmap.py
@@ -12,7 +12,6 @@ import struct
 import sys
 from pathlib import Path
 
-from PIL import Image
 
 
 def _extract_size(data: bytes) -> tuple[int, int]:
@@ -38,6 +37,7 @@ def _read_pixels(data: bytes, width: int, height: int) -> bytes:
 
 def convert(src: Path, dst: Path) -> None:
     """将 ``src`` 转换为 PNG 并保存到 ``dst``。"""
+    from PIL import Image
     data = src.read_bytes()
     width, height = _extract_size(data)
     if width <= 0 or height <= 0:

--- a/tests/test_convert_cpbitmap.py
+++ b/tests/test_convert_cpbitmap.py
@@ -1,0 +1,48 @@
+import math
+import struct
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'python'))
+
+import convert_cpbitmap as cp
+
+SAMPLE = Path(__file__).resolve().parents[1] / 'samples' / 'LockBackground.cpbitmap'
+
+def test_extract_size_sample():
+    data = SAMPLE.read_bytes()
+    width, height = cp._extract_size(data)
+    assert (width, height) == (1943, 2591)
+
+def test_read_pixels_length():
+    data = SAMPLE.read_bytes()
+    width, height = cp._extract_size(data)
+    pixels = cp._read_pixels(data, width, height)
+    assert len(pixels) == width * height * 4
+    assert pixels[:16] == data[:16]
+
+def test_extract_size_small_file_error():
+    try:
+        cp._extract_size(b'123')
+    except ValueError:
+        pass
+    else:
+        raise AssertionError('ValueError not raised')
+
+def test_read_pixels_padding():
+    width, height = 5, 2
+    stride = math.ceil(width / 16) * 16 * 4
+    buf = bytearray(stride * height)
+    for y in range(height):
+        for x in range(stride // 4):
+            start = y * stride + x * 4
+            buf[start:start+4] = struct.pack('BBBB', x, x, x, 255)
+    footer = struct.pack('<6i', 0, width, height, 0, 0, 0)
+    data = bytes(buf) + footer
+    pixels = cp._read_pixels(data, width, height)
+    expected = b''.join(
+        struct.pack('BBBB', x, x, x, 255)
+        for y in range(height)
+        for x in range(width)
+    )
+    assert pixels == expected


### PR DESCRIPTION
## Summary
- refactor convert_cpbitmap to import Pillow lazily
- add unit tests for helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68400636ca708321a4a17422ffa7d911